### PR TITLE
Fix login for Tauron's Keycloak migration

### DIFF
--- a/src/elicznik/elicznik.py
+++ b/src/elicznik/elicznik.py
@@ -3,6 +3,7 @@
 import collections
 import csv
 import datetime
+import re
 
 from .session import Session
 
@@ -20,14 +21,30 @@ class ELicznikBase:
 
     def login(self):
         self.session = Session()
-        self.session.get(self.LOGIN_URL)
+        SERVICE_URL = "https://elicznik.tauron-dystrybucja.pl"
+
+        # Step 1: GET login page with service parameter to get Keycloak form
+        r1 = self.session.get(f"{self.LOGIN_URL}?service={SERVICE_URL}", allow_redirects=True)
+
+        # Step 2: Extract Keycloak form action URL
+        form_match = re.search(
+            r'<form[^>]+id="kc-form-login"[^>]+action="([^"]+)"',
+            r1.text,
+        )
+        if form_match is None:
+            raise RuntimeError("Keycloak login form not found")
+
+        form_action = form_match.group(1).replace("&amp;", "&")
+
+        # Step 3: POST credentials to Keycloak form action URL
         self.session.post(
-            self.LOGIN_URL,
+            form_action,
             data={
                 "username": self.username,
                 "password": self.password,
-                "service": "https://elicznik.tauron-dystrybucja.pl",
+                "credentialId": "",
             },
+            allow_redirects=True,
         )
         if self.site is not None:
             self.session.post(


### PR DESCRIPTION
## Summary

Tauron migrated their authentication from a simple POST to `/login` to a Keycloak-based flow. The old login endpoint now returns 404, breaking all authentication.

The new flow:
1. GET the login page with `?service=` parameter — returns a Keycloak login form
2. Extract the dynamic form action URL from the `kc-form-login` form
3. POST credentials to that Keycloak URL with a `credentialId` field

## Test plan
- Verified working against live Tauron eLicznik API (both CSV and Chart endpoints return data after login)
- Tested on macOS (Python 3.14) and Linux